### PR TITLE
Mejorada visualización del apartado de ayuda y la barra lateral

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,50 +121,18 @@ This command will build the Docker images and start the full stack behind the ga
 - External bot API documentation (through gateway): [https://localhost/external/docs](https://localhost/external/docs)
 - External bot OpenAPI contract (through gateway): [https://localhost/external/docs/openapi.json](https://localhost/external/docs/openapi.json)
 
-### HTTPS in the gateway
+### HTTPS certificates
 
-The public entry point is the `gateway`. HTTPS is terminated there, while internal traffic to `webapp`, `auth`, `gamey`, and `stats` remains plain HTTP inside Docker.
+The public entry point is the `gateway`. HTTPS is configured there, while internal traffic to `webapp`, `auth`, `gamey`, and `stats` remains inside Docker.
 
 Certificate placement:
 
-- Put the public certificate in `gateway/certs/server.crt`
-- Put the private key in `gateway/certs/server.key`
+- The public certificate is in `gateway/certs/server.crt`
+- The private key is in `gateway/certs/server.key`
 
-These files are mounted into the container at `/app/certs` and used by the gateway through:
+These files are mounted into the container at `/app/certs` and loaded by the gateway with the default Docker Compose configuration.
 
-- `HTTPS_CERT_PATH=/app/certs/server.crt`
-- `HTTPS_KEY_PATH=/app/certs/server.key`
-
-Default Docker ports:
-
-- Host `443` -> gateway HTTPS listener
-- Host `8080` -> gateway HTTP listener
-
-Important deployment note:
-
-- If you do not want HTTP at all, set `HTTP_REDIRECT_ENABLED=false` and do not use host port `80`.
-- If you want automatic redirect from HTTP to HTTPS, set `HTTP_REDIRECT_ENABLED=true` and map host `80` to the gateway HTTP listener instead of exposing that port from any other service.
-- Only the `gateway` should publish public web ports. `webapp` must stay internal to avoid port conflicts.
-
-Recommended VM setup without risking another port-80 collision:
-
-```powershell
-$env:HTTP_REDIRECT_ENABLED="false"
-$env:GATEWAY_HTTPS_HOST_PORT="443"
-$env:GATEWAY_HTTP_HOST_PORT="8080"
-docker-compose up --build -d
-```
-
-If you want `http://...` to redirect to `https://...`, use:
-
-```powershell
-$env:HTTP_REDIRECT_ENABLED="true"
-$env:GATEWAY_HTTPS_HOST_PORT="443"
-$env:GATEWAY_HTTP_HOST_PORT="80"
-docker-compose up --build -d
-```
-
-With that configuration there is no duplicate use of port `80`, because the only container binding that host port is the `gateway`.
+For local development, self-signed certificates can be used. 
 
 ### Without Docker
 

--- a/webapp/src/theme.tsx
+++ b/webapp/src/theme.tsx
@@ -875,6 +875,69 @@ export const uiSx = {
     fontSize: '0.86rem',
     letterSpacing: 0.12,
   } satisfies SxProps<Theme>,
+  helpFilterRow: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: 1,
+    mb: 2.2,
+  } satisfies SxProps<Theme>,
+  helpFilterButton: (selected: boolean): SxProps<Theme> => ({
+    minWidth: 0,
+    height: 38,
+    px: 1.8,
+    py: 0.7,
+    borderRadius: 999,
+    fontWeight: 800,
+    letterSpacing: 0.16,
+    color: selected ? '#112418' : '#9ad7a7',
+    borderColor: selected ? '#75d08d' : 'rgba(117, 208, 141, 0.5)',
+    background: selected
+      ? 'linear-gradient(135deg, #9bf0ae 0%, #75d08d 100%)'
+      : 'rgba(21, 47, 30, 0.52)',
+    '&:hover': {
+      borderColor: '#8be6a2',
+      background: selected
+        ? 'linear-gradient(135deg, #a5f3b6 0%, #82db99 100%)'
+        : 'rgba(27, 61, 38, 0.72)',
+    },
+  }),
+  helpSectionsColumn: {
+    display: 'grid',
+    gap: 2.25,
+  } satisfies SxProps<Theme>,
+  helpSectionGroup: {
+    display: 'grid',
+    gap: 1.2,
+  } satisfies SxProps<Theme>,
+  helpSectionHeading: {
+    color: '#8fe3a2',
+    fontWeight: 900,
+    letterSpacing: 0.22,
+    textTransform: 'uppercase',
+  } satisfies SxProps<Theme>,
+  helpSectionGrid: {
+    display: 'grid',
+    gap: 1.5,
+    gridTemplateColumns: { xs: '1fr', lg: '1fr 1fr' },
+  } satisfies SxProps<Theme>,
+  helpCard: {
+    border: '1px solid',
+    borderColor: 'divider',
+    borderRadius: 1.8,
+    backgroundColor: 'rgba(44, 42, 39, 0.65)',
+    px: 1.6,
+    py: 1.4,
+    display: 'grid',
+    gap: 0.85,
+    alignContent: 'start',
+  } satisfies SxProps<Theme>,
+  helpCardTitle: {
+    fontWeight: 800,
+    letterSpacing: 0.18,
+  } satisfies SxProps<Theme>,
+  helpCardText: {
+    lineHeight: 1.6,
+  } satisfies SxProps<Theme>,
   historyStatsGrid: {
     display: 'grid',
     gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, minmax(0, 1fr))', xl: 'repeat(4, minmax(0, 1fr))' },

--- a/webapp/src/theme.tsx
+++ b/webapp/src/theme.tsx
@@ -45,6 +45,8 @@ export const uiColors = {
   },
 } as const;
 
+const desktopSidebarViewportOffset = 118;
+
 type HistoryStatTone = 'neutral' | 'win' | 'loss' | 'info';
 type GameCountdownTone = 'self' | 'opponent' | 'disconnect';
 type BoardOwner = 'human' | 'opponent' | 'empty';
@@ -513,7 +515,7 @@ export const uiSx = {
   } satisfies SxProps<Theme>,
   appBody: {
     display: 'flex',
-    alignItems: 'stretch',
+    alignItems: { xs: 'stretch', md: 'flex-start' },
     width: '100%',
     flex: 1,
     minHeight: 0,
@@ -532,6 +534,7 @@ export const uiSx = {
   sidebar: {
     width: { xs: '100%', md: 206 },
     flexShrink: 0,
+    alignSelf: { xs: 'auto', md: 'flex-start' },
     px: 2,
     py: 2.5,
     borderRight: { xs: 'none', md: `1px solid ${uiColors.border.faint}` },
@@ -543,7 +546,12 @@ export const uiSx = {
     flexDirection: 'column',
     gap: 1.5,
     position: 'relative',
+    top: { md: 0 },
+    height: { md: `calc(100dvh - ${desktopSidebarViewportOffset}px)` },
     overflow: 'visible',
+    '@media (min-width: 900px)': {
+      position: 'sticky',
+    },
   } satisfies SxProps<Theme>,
   sidebarItem: (active: boolean): SxProps<Theme> => ({
     border: 'none',

--- a/webapp/src/views/HelpView.tsx
+++ b/webapp/src/views/HelpView.tsx
@@ -3,19 +3,25 @@ import { Box, Button, Paper, Typography } from '@mui/material';
 import { uiSx } from '../theme';
 
 type HelpCategoryId = 'all' | 'play' | 'online' | 'account' | 'issues';
+type SectionCategoryId = Exclude<HelpCategoryId, 'all'>;
 
 type HelpSection = {
   title: string;
   body: string[];
-  category: Exclude<HelpCategoryId, 'all'>;
 };
 
 type HelpCategory = {
+  id: SectionCategoryId;
+  label: string;
+  sections: HelpSection[];
+};
+
+type HelpFilter = {
   id: HelpCategoryId;
   label: string;
 };
 
-const helpCategories: HelpCategory[] = [
+const helpFilters: HelpFilter[] = [
   { id: 'all', label: 'Todo' },
   { id: 'play', label: 'Jugar' },
   { id: 'online', label: 'Online' },
@@ -23,104 +29,109 @@ const helpCategories: HelpCategory[] = [
   { id: 'issues', label: 'Problemas' },
 ];
 
-const helpSections: HelpSection[] = [
+const helpCategories: HelpCategory[] = [
   {
-    title: 'Reglas basicas',
-    category: 'play',
-    body: [
-      'Tu objetivo es unir los tres lados del triangulo con una sola cadena continua de tus fichas.',
-      'No hace falta llenar mucho tablero: gana quien complete antes esa conexion.',
+    id: 'play',
+    label: 'Jugar',
+    sections: [
+      {
+        title: 'Reglas basicas',
+        body: [
+          'Tu objetivo es unir los tres lados del triangulo con una sola cadena continua de tus fichas.',
+          'No hace falta llenar mucho tablero: gana quien complete antes esa conexion.',
+        ],
+      },
+      {
+        title: 'Si quieres empezar rapido',
+        body: [
+          'Si buscas una partida tranquila, empieza contra bot en un tablero pequeno. Terminaras antes y te sera mas facil leer la posicion.',
+          'Si quieres mas estrategia, aumenta el tamano del tablero. Cuanto mas grande, mas caminos y mas posibilidades hay.',
+        ],
+      },
+      {
+        title: 'Como jugar durante una partida',
+        body: [
+          'Pulsa una celda vacia para colocar tu ficha cuando sea tu turno.',
+          'Si necesitas cortar el ritmo o la posicion se ha torcido, puedes usar Ceder turno o Rendirse.',
+          'Si sales de la vista del tablero por error, la partida activa se queda guardada para que puedas retomarla.',
+        ],
+      },
+      {
+        title: 'Ayuda con las pistas',
+        body: [
+          'El boton Pista te sugiere un movimiento cuando puedes jugar. No coloca la ficha por ti: la decision final sigue siendo tuya.',
+          'Usala cuando no veas una continuacion clara o cuando quieras comparar tu idea con una alternativa.',
+        ],
+      },
     ],
   },
   {
-    title: 'Si quieres empezar rapido',
-    category: 'play',
-    body: [
-      'Si buscas una partida tranquila, empieza contra bot en un tablero pequeno. Terminaras antes y te sera mas facil leer la posicion.',
-      'Si quieres mas estrategia, aumenta el tamano del tablero. Cuanto mas grande, mas caminos y mas posibilidades hay.',
+    id: 'online',
+    label: 'Online',
+    sections: [
+      {
+        title: 'Si juegas online',
+        body: [
+          'Pulsa Buscar rival y espera a que aparezca partida. Si cambias de idea, puedes cancelar la busqueda.',
+          'La busqueda online cuenta por identidad: no puedes emparejarte contigo mismo, ni con tu mismo usuario, ni con la misma sesion de invitado abierta en otra pestana del mismo navegador.',
+          'Si ya estabas buscando y vuelves a entrar, la aplicacion intenta recuperar esa busqueda o esa partida para que no pierdas el estado.',
+        ],
+      },
+      {
+        title: 'Que significan los avisos de tiempo',
+        body: [
+          'Si ves Tu turno o Turno del rival con cuenta atras, significa que esa jugada tiene tiempo limite.',
+          'Si el tiempo llega a cero, el turno se cede automaticamente.',
+          'Si aparece Rival desconectado, solo tienes que esperar: si no vuelve a tiempo, la partida se cerrara a tu favor por abandono.',
+        ],
+      },
     ],
   },
   {
-    title: 'Como jugar durante una partida',
-    category: 'play',
-    body: [
-      'Pulsa una celda vacia para colocar tu ficha cuando sea tu turno.',
-      'Si necesitas cortar el ritmo o la posicion se ha torcido, puedes usar Ceder turno o Rendirse.',
-      'Si sales de la vista del tablero por error, la partida activa se queda guardada para que puedas retomarla.',
+    id: 'account',
+    label: 'Cuenta',
+    sections: [
+      {
+        title: 'Cuenta, invitado y estadisticas',
+        body: [
+          'Puedes entrar como invitado para probar el juego sin registrarte.',
+          'Si quieres conservar historial, victorias, derrotas y ver tus estadisticas, necesitas iniciar sesion con una cuenta registrada.',
+          'Dentro del historial, puedes pulsar las cabeceras de Resultado, Modo, Bot, Ganador y Fecha para filtrar u ordenar las partidas.',
+          'Los filtros se pueden combinar entre si, asi que puedes quedarte, por ejemplo, solo con victorias contra bot o reordenar por las mas antiguas.',
+        ],
+      },
     ],
   },
   {
-    title: 'Ayuda con las pistas',
-    category: 'play',
-    body: [
-      'El boton Pista te sugiere un movimiento cuando puedes jugar. No coloca la ficha por ti: la decision final sigue siendo tuya.',
-      'Usala cuando no veas una continuacion clara o cuando quieras comparar tu idea con una alternativa.',
-    ],
-  },
-  {
-    title: 'Si juegas online',
-    category: 'online',
-    body: [
-      'Pulsa Buscar rival y espera a que aparezca partida. Si cambias de idea, puedes cancelar la busqueda.',
-      'La busqueda online cuenta por identidad: no puedes emparejarte contigo mismo, ni con tu mismo usuario, ni con la misma sesion de invitado abierta en otra pestana del mismo navegador.',
-      'Si ya estabas buscando y vuelves a entrar, la aplicacion intenta recuperar esa busqueda o esa partida para que no pierdas el estado.',
-    ],
-  },
-  {
-    title: 'Que significan los avisos de tiempo',
-    category: 'online',
-    body: [
-      'Si ves Tu turno o Turno del rival con cuenta atras, significa que esa jugada tiene tiempo limite.',
-      'Si el tiempo llega a cero, el turno se cede automaticamente.',
-      'Si aparece Rival desconectado, solo tienes que esperar: si no vuelve a tiempo, la partida se cerrara a tu favor por abandono.',
-    ],
-  },
-  {
-    title: 'Cuenta, invitado y estadisticas',
-    category: 'account',
-    body: [
-      'Puedes entrar como invitado para probar el juego sin registrarte.',
-      'Si quieres conservar historial, victorias, derrotas y ver tus estadisticas, necesitas iniciar sesion con una cuenta registrada.',
-      'Dentro del historial, puedes pulsar las cabeceras de Resultado, Modo, Bot, Ganador y Fecha para filtrar u ordenar las partidas.',
-      'Los filtros se pueden combinar entre si, asi que puedes quedarte, por ejemplo, solo con victorias contra bot o reordenar por las mas antiguas.',
-    ],
-  },
-  {
-    title: 'Si algo no te cuadra',
-    category: 'issues',
-    body: [
-      'Si una partida parece quedarse a medias, vuelve a la pantalla principal y usa Volver a la partida si aparece.',
-      'Si estabas en matchmaking y quieres empezar de cero, cancela la busqueda actual antes de lanzar otra.',
+    id: 'issues',
+    label: 'Problemas',
+    sections: [
+      {
+        title: 'Si algo no te cuadra',
+        body: [
+          'Si una partida parece quedarse a medias, vuelve a la pantalla principal y usa Volver a la partida si aparece.',
+          'Si estabas en matchmaking y quieres empezar de cero, cancela la busqueda actual antes de lanzar otra.',
+        ],
+      },
     ],
   },
 ];
 
-const sectionOrder: Exclude<HelpCategoryId, 'all'>[] = ['play', 'online', 'account', 'issues'];
+function getVisibleCategories(selectedCategory: HelpCategoryId): HelpCategory[] {
+  if (selectedCategory === 'all') {
+    return helpCategories;
+  }
 
-const categoryHeadings: Record<Exclude<HelpCategoryId, 'all'>, string> = {
-  play: 'Jugar',
-  online: 'Online',
-  account: 'Cuenta',
-  issues: 'Problemas',
-};
+  return helpCategories.filter((category) => category.id === selectedCategory);
+}
 
 const HelpView: React.FC = () => {
   const [selectedCategory, setSelectedCategory] = useState<HelpCategoryId>('all');
 
-  const groupedSections = useMemo(() => {
-    const visibleSections =
-      selectedCategory === 'all'
-        ? helpSections
-        : helpSections.filter((section) => section.category === selectedCategory);
-
-    return sectionOrder
-      .map((category) => ({
-        category,
-        heading: categoryHeadings[category],
-        sections: visibleSections.filter((section) => section.category === category),
-      }))
-      .filter((group) => group.sections.length > 0);
-  }, [selectedCategory]);
+  const visibleCategories = useMemo(
+    () => getVisibleCategories(selectedCategory),
+    [selectedCategory],
+  );
 
   return (
     <Paper sx={uiSx.historyFullscreenCard}>
@@ -135,32 +146,32 @@ const HelpView: React.FC = () => {
       </Box>
 
       <Box sx={uiSx.helpFilterRow}>
-        {helpCategories.map((category) => {
-          const selected = category.id === selectedCategory;
+        {helpFilters.map((filter) => {
+          const selected = selectedCategory === filter.id;
 
           return (
             <Button
-              key={category.id}
+              key={filter.id}
               type="button"
               variant={selected ? 'contained' : 'outlined'}
-              onClick={() => setSelectedCategory(category.id)}
+              onClick={() => setSelectedCategory(filter.id)}
               sx={uiSx.helpFilterButton(selected)}
             >
-              {category.label}
+              {filter.label}
             </Button>
           );
         })}
       </Box>
 
       <Box sx={uiSx.helpSectionsColumn}>
-        {groupedSections.map((group) => (
-          <Box key={group.category} sx={uiSx.helpSectionGroup}>
+        {visibleCategories.map((category) => (
+          <Box key={category.id} sx={uiSx.helpSectionGroup}>
             <Typography variant="h6" sx={uiSx.helpSectionHeading}>
-              {group.heading}
+              {category.label}
             </Typography>
 
             <Box sx={uiSx.helpSectionGrid}>
-              {group.sections.map((section) => (
+              {category.sections.map((section) => (
                 <Box key={section.title} sx={uiSx.helpCard}>
                   <Typography variant="subtitle1" sx={uiSx.helpCardTitle}>
                     {section.title}

--- a/webapp/src/views/HelpView.tsx
+++ b/webapp/src/views/HelpView.tsx
@@ -1,15 +1,32 @@
-import React from 'react';
-import { Box, Paper, Typography } from '@mui/material';
+import React, { useMemo, useState } from 'react';
+import { Box, Button, Paper, Typography } from '@mui/material';
 import { uiSx } from '../theme';
+
+type HelpCategoryId = 'all' | 'play' | 'online' | 'account' | 'issues';
 
 type HelpSection = {
   title: string;
   body: string[];
+  category: Exclude<HelpCategoryId, 'all'>;
 };
+
+type HelpCategory = {
+  id: HelpCategoryId;
+  label: string;
+};
+
+const helpCategories: HelpCategory[] = [
+  { id: 'all', label: 'Todo' },
+  { id: 'play', label: 'Jugar' },
+  { id: 'online', label: 'Online' },
+  { id: 'account', label: 'Cuenta' },
+  { id: 'issues', label: 'Problemas' },
+];
 
 const helpSections: HelpSection[] = [
   {
     title: 'Reglas basicas',
+    category: 'play',
     body: [
       'Tu objetivo es unir los tres lados del triangulo con una sola cadena continua de tus fichas.',
       'No hace falta llenar mucho tablero: gana quien complete antes esa conexion.',
@@ -17,6 +34,7 @@ const helpSections: HelpSection[] = [
   },
   {
     title: 'Si quieres empezar rapido',
+    category: 'play',
     body: [
       'Si buscas una partida tranquila, empieza contra bot en un tablero pequeno. Terminaras antes y te sera mas facil leer la posicion.',
       'Si quieres mas estrategia, aumenta el tamano del tablero. Cuanto mas grande, mas caminos y mas posibilidades hay.',
@@ -24,6 +42,7 @@ const helpSections: HelpSection[] = [
   },
   {
     title: 'Como jugar durante una partida',
+    category: 'play',
     body: [
       'Pulsa una celda vacia para colocar tu ficha cuando sea tu turno.',
       'Si necesitas cortar el ritmo o la posicion se ha torcido, puedes usar Ceder turno o Rendirse.',
@@ -32,6 +51,7 @@ const helpSections: HelpSection[] = [
   },
   {
     title: 'Ayuda con las pistas',
+    category: 'play',
     body: [
       'El boton Pista te sugiere un movimiento cuando puedes jugar. No coloca la ficha por ti: la decision final sigue siendo tuya.',
       'Usala cuando no veas una continuacion clara o cuando quieras comparar tu idea con una alternativa.',
@@ -39,6 +59,7 @@ const helpSections: HelpSection[] = [
   },
   {
     title: 'Si juegas online',
+    category: 'online',
     body: [
       'Pulsa Buscar rival y espera a que aparezca partida. Si cambias de idea, puedes cancelar la busqueda.',
       'La busqueda online cuenta por identidad: no puedes emparejarte contigo mismo, ni con tu mismo usuario, ni con la misma sesion de invitado abierta en otra pestana del mismo navegador.',
@@ -47,6 +68,7 @@ const helpSections: HelpSection[] = [
   },
   {
     title: 'Que significan los avisos de tiempo',
+    category: 'online',
     body: [
       'Si ves Tu turno o Turno del rival con cuenta atras, significa que esa jugada tiene tiempo limite.',
       'Si el tiempo llega a cero, el turno se cede automaticamente.',
@@ -55,6 +77,7 @@ const helpSections: HelpSection[] = [
   },
   {
     title: 'Cuenta, invitado y estadisticas',
+    category: 'account',
     body: [
       'Puedes entrar como invitado para probar el juego sin registrarte.',
       'Si quieres conservar historial, victorias, derrotas y ver tus estadisticas, necesitas iniciar sesion con una cuenta registrada.',
@@ -64,6 +87,7 @@ const helpSections: HelpSection[] = [
   },
   {
     title: 'Si algo no te cuadra',
+    category: 'issues',
     body: [
       'Si una partida parece quedarse a medias, vuelve a la pantalla principal y usa Volver a la partida si aparece.',
       'Si estabas en matchmaking y quieres empezar de cero, cancela la busqueda actual antes de lanzar otra.',
@@ -71,7 +95,33 @@ const helpSections: HelpSection[] = [
   },
 ];
 
+const sectionOrder: Exclude<HelpCategoryId, 'all'>[] = ['play', 'online', 'account', 'issues'];
+
+const categoryHeadings: Record<Exclude<HelpCategoryId, 'all'>, string> = {
+  play: 'Jugar',
+  online: 'Online',
+  account: 'Cuenta',
+  issues: 'Problemas',
+};
+
 const HelpView: React.FC = () => {
+  const [selectedCategory, setSelectedCategory] = useState<HelpCategoryId>('all');
+
+  const groupedSections = useMemo(() => {
+    const visibleSections =
+      selectedCategory === 'all'
+        ? helpSections
+        : helpSections.filter((section) => section.category === selectedCategory);
+
+    return sectionOrder
+      .map((category) => ({
+        category,
+        heading: categoryHeadings[category],
+        sections: visibleSections.filter((section) => section.category === category),
+      }))
+      .filter((group) => group.sections.length > 0);
+  }, [selectedCategory]);
+
   return (
     <Paper sx={uiSx.historyFullscreenCard}>
       <Box sx={uiSx.historyHeader}>
@@ -84,37 +134,46 @@ const HelpView: React.FC = () => {
         Si vienes con una duda puntual, empieza por el bloque que mas se parezca a tu situacion.
       </Box>
 
-      <Box
-        sx={{
-          display: 'grid',
-          gap: 1.5,
-          gridTemplateColumns: { xs: '1fr', lg: '1fr 1fr' },
-        }}
-      >
-        {helpSections.map((section) => (
-          <Box
-            key={section.title}
-            sx={{
-              border: '1px solid',
-              borderColor: 'divider',
-              borderRadius: 1.8,
-              backgroundColor: 'rgba(44, 42, 39, 0.65)',
-              px: 1.6,
-              py: 1.4,
-              display: 'grid',
-              gap: 0.85,
-              alignContent: 'start',
-            }}
-          >
-            <Typography variant="subtitle1" sx={{ fontWeight: 800, letterSpacing: 0.18 }}>
-              {section.title}
+      <Box sx={uiSx.helpFilterRow}>
+        {helpCategories.map((category) => {
+          const selected = category.id === selectedCategory;
+
+          return (
+            <Button
+              key={category.id}
+              type="button"
+              variant={selected ? 'contained' : 'outlined'}
+              onClick={() => setSelectedCategory(category.id)}
+              sx={uiSx.helpFilterButton(selected)}
+            >
+              {category.label}
+            </Button>
+          );
+        })}
+      </Box>
+
+      <Box sx={uiSx.helpSectionsColumn}>
+        {groupedSections.map((group) => (
+          <Box key={group.category} sx={uiSx.helpSectionGroup}>
+            <Typography variant="h6" sx={uiSx.helpSectionHeading}>
+              {group.heading}
             </Typography>
 
-            {section.body.map((paragraph) => (
-              <Typography key={paragraph} color="text.secondary" sx={{ lineHeight: 1.6 }}>
-                {paragraph}
-              </Typography>
-            ))}
+            <Box sx={uiSx.helpSectionGrid}>
+              {group.sections.map((section) => (
+                <Box key={section.title} sx={uiSx.helpCard}>
+                  <Typography variant="subtitle1" sx={uiSx.helpCardTitle}>
+                    {section.title}
+                  </Typography>
+
+                  {section.body.map((paragraph) => (
+                    <Typography key={paragraph} color="text.secondary" sx={uiSx.helpCardText}>
+                      {paragraph}
+                    </Typography>
+                  ))}
+                </Box>
+              ))}
+            </Box>
           </Box>
         ))}
       </Box>


### PR DESCRIPTION
Se mejora la navegación de la sección de ayuda agrupando el contenido en cuatro bloques y añadiendo filtros para mostrar cada sección o todo el contenido.

Además, se ajusta la barra lateral para que permanezca visible al hacer scroll en páginas largas, manteniendo accesibles los botones principales y la acción de sesión.

Modificado apartado de https del readme.