### PR TITLE
Arreglo fallo en prometheus

### DIFF
--- a/gateway/gateway-service.js
+++ b/gateway/gateway-service.js
@@ -308,8 +308,16 @@ function buildRedirectDestination({ redirectHostname, httpsPort, requestPath = '
   return destination.toString();
 }
 
-function createRedirectApp({ httpsPort = 443, redirectHostname = DEFAULT_REDIRECT_HTTPS_HOST } = {}) {
+function createRedirectApp({
+  httpsPort = 443,
+  redirectHostname = DEFAULT_REDIRECT_HTTPS_HOST,
+  metricsHandler = null,
+} = {}) {
   const app = express();
+
+  if (metricsHandler) {
+    app.get('/metrics', metricsHandler);
+  }
 
   app.use((req, res) => {
     const destination = buildRedirectDestination({
@@ -1068,11 +1076,11 @@ function createApp({
     }
   }
 
-  return { app, proxyRoutes };
+  return { app, metrics, proxyRoutes };
 }
 
 function start({ port = DEFAULT_PORT, env = process.env } = {}) {
-  const { app } = createApp({ env });
+  const { app, metrics } = createApp({ env });
   const tlsOptions = loadTlsOptions(env);
 
   if (!tlsOptions) {
@@ -1099,6 +1107,7 @@ function start({ port = DEFAULT_PORT, env = process.env } = {}) {
     const redirectApp = createRedirectApp({
       httpsPort: redirectHttpsPort,
       redirectHostname: redirectHost,
+      metricsHandler: metrics.handler,
     });
     httpServer = http.createServer(redirectApp);
     httpServer.listen(port, () => {

--- a/gateway/tests/services/gateway-service.test.js
+++ b/gateway/tests/services/gateway-service.test.js
@@ -329,6 +329,25 @@ test('createRedirectApp redirects requests to the configured HTTPS port', async 
   });
 });
 
+test('createRedirectApp exposes metrics over HTTP when a metrics handler is configured', async () => {
+  const { metrics } = createApp({ proxyFactory: noopProxyFactory });
+  const redirectApp = createRedirectApp({
+    httpsPort: 8443,
+    redirectHostname: 'gateway.example.com',
+    metricsHandler: metrics.handler,
+  });
+
+  await withServer(redirectApp, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/metrics`, {
+      redirect: 'manual',
+    });
+    const body = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.match(body, /# TYPE yovi_http_requests_total counter/);
+  });
+});
+
 // Redirect hostnames come from trusted server configuration only.
 test('getRedirectHostname falls back to localhost when unset', () => {
   assert.equal(getRedirectHostname({}), 'localhost');


### PR DESCRIPTION
Permitir métricas del gateway sin redirección HTTPS